### PR TITLE
Say hello

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,4 +3,3 @@ uvicorn[standard]==0.32.1
 pydantic==2.10.4
 python-dotenv==1.0.1
 supabase==2.8.1
-postgrest==0.16.11


### PR DESCRIPTION
Remove `postgrest` from `requirements.txt` to resolve dependency conflicts during deployment.

The `supabase` package already includes `postgrest` as a dependency, causing a conflict when `postgrest` was explicitly specified in `requirements.txt`. Removing the explicit `postgrest` entry allows `supabase` to manage its own `postgrest` dependency.

---
<a href="https://cursor.com/background-agent?bcId=bc-acb2ebe2-d382-4625-a202-59fff1b5c38a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-acb2ebe2-d382-4625-a202-59fff1b5c38a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>